### PR TITLE
Add accessors for PubRestrictionEntry + some refactors

### DIFF
--- a/src/main/java/com/iab/gdpr/ConsentInfo.java
+++ b/src/main/java/com/iab/gdpr/ConsentInfo.java
@@ -1,6 +1,7 @@
 package com.iab.gdpr;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 
 public interface ConsentInfo {
@@ -224,6 +225,13 @@ public interface ConsentInfo {
 	 */
 	default boolean isCustomPurposeLegitInterestEstablished(int purposeId) {
 		return false;
+	}
+
+	/**
+	 * @return list of publisher restriction entries
+	 */
+	default List<PubRestrictionEntry> getPublisherRestrictions() {
+		return Collections.emptyList();
 	}
 
 

--- a/src/main/java/com/iab/gdpr/ConsentStringParser.java
+++ b/src/main/java/com/iab/gdpr/ConsentStringParser.java
@@ -240,36 +240,13 @@ public class ConsentStringParser implements ConsentInfo {
 		return isPurposeConsented(purpose.getValue());
 	}
 
-	private boolean findVendorIdInRange(int vendorId) {
-		int limit = rangeEntries.size();
-		if (limit == 0) {
-			return false;
-		}
-		int index = limit / 2;
-		while (index >= 0 && index < limit) {
-			RangeEntry entry = rangeEntries.get(index);
-			if (entry.containsVendorId(vendorId)) {
-				return true;
-			}
-			if (index == 0 || index == limit - 1) {
-				return false;
-			}
-			if (entry.idIsGreaterThanMax(vendorId)) {
-				index = (index + ((limit - index) / 2));
-			} else {
-				index = index / 2;
-			}
-		}
-		return false;
-	}
-
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
 	public boolean isVendorConsented(int vendorId) {
 		if (vendorEncodingType == VENDOR_ENCODING_RANGE) {
-			boolean present = findVendorIdInRange(vendorId);
+			boolean present = RangeEntry.isVendorIdInRange(vendorId, rangeEntries);
 			return present != defaultConsent;
 		} else {
 			boolean allowed;

--- a/src/main/java/com/iab/gdpr/ConsentStringParserV2.java
+++ b/src/main/java/com/iab/gdpr/ConsentStringParserV2.java
@@ -195,29 +195,6 @@ public class ConsentStringParserV2 implements ConsentInfo {
 		this.customPurposeLegitInterests = bits.getBitList(offset, numCustomPurposes);
 	}
 
-	private boolean findVendorIdInRange(int vendorId, List<RangeEntry> rangeEntries) {
-		int limit = rangeEntries.size();
-		if (limit == 0) {
-			return false;
-		}
-		int index = limit / 2;
-		while (index >= 0 && index < limit) {
-			RangeEntry entry = rangeEntries.get(index);
-			if (entry.containsVendorId(vendorId)) {
-				return true;
-			}
-			if (index == 0 || index == limit - 1) {
-				return false;
-			}
-			if (entry.idIsGreaterThanMax(vendorId)) {
-				index = (index + ((limit - index) / 2));
-			} else {
-				index = index / 2;
-			}
-		}
-		return false;
-	}
-
 	private boolean findIdInBitField(int index, List<Boolean> bitField) {
 		if (index < 1 || index > bitField.size()) {
 			return false;
@@ -332,7 +309,7 @@ public class ConsentStringParserV2 implements ConsentInfo {
 		if (vendorConsentsBitField != null) {
 			return findIdInBitField(vendorId, vendorConsentsBitField);
 		} else {
-			return findVendorIdInRange(vendorId, vendorConsentsRanges);
+			return  RangeEntry.isVendorIdInRange(vendorId, vendorConsentsRanges);
 		}
 	}
 
@@ -422,7 +399,7 @@ public class ConsentStringParserV2 implements ConsentInfo {
 		if (vendorLegitInterestsBitField != null) {
 			return findIdInBitField(vendorId, vendorLegitInterestsBitField);
 		} else {
-			return findVendorIdInRange(vendorId, vendorLegitInterestRanges);
+			return RangeEntry.isVendorIdInRange(vendorId, vendorLegitInterestRanges);
 		}
 	}
 
@@ -434,7 +411,7 @@ public class ConsentStringParserV2 implements ConsentInfo {
 		if (vendorDisclosureBitField != null) {
 			return findIdInBitField(vendorId, vendorDisclosureBitField);
 		} else {
-			return findVendorIdInRange(vendorId, vendorDisclosureRanges);
+			return RangeEntry.isVendorIdInRange(vendorId, vendorDisclosureRanges);
 		}
 	}
 
@@ -446,7 +423,7 @@ public class ConsentStringParserV2 implements ConsentInfo {
 		if (vendorAllowancesBitField != null) {
 			return findIdInBitField(vendorId, vendorAllowancesBitField);
 		} else {
-			return findVendorIdInRange(vendorId, vendorAllowancesRanges);
+			return RangeEntry.isVendorIdInRange(vendorId, vendorAllowancesRanges);
 		}
 	}
 
@@ -480,6 +457,14 @@ public class ConsentStringParserV2 implements ConsentInfo {
 	@Override
 	public boolean isCustomPurposeLegitInterestEstablished(int purposeId) {
 		return findIdInBitField(purposeId, customPurposeLegitInterests);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public List<PubRestrictionEntry> getPublisherRestrictions() {
+		return new ArrayList<>(publisherRestrictions);
 	}
 
 	private static class RangeOrBitFieldParser {

--- a/src/main/java/com/iab/gdpr/PubRestrictionEntry.java
+++ b/src/main/java/com/iab/gdpr/PubRestrictionEntry.java
@@ -22,6 +22,22 @@ public class PubRestrictionEntry {
 		this.entries = entries;
 	}
 
+	public int getPurposeId() {
+		return purposeId;
+	}
+
+	public RestrictionType getType() {
+		return type;
+	}
+
+	public List<RangeEntry> getEntries() {
+		return new ArrayList<>(entries);
+	}
+
+	public boolean isVendorRestricted(int vendorId) {
+		return RangeEntry.isVendorIdInRange(vendorId, entries);
+	}
+
 	public enum RestrictionType {
 		NOT_ALLOWED(0), REQUIRE_CONSENT(1), REQUIRE_LEGIT_INTEREST(2), UNDEFINED(3), UNKNOWN(-1);
 		private final int value;

--- a/src/main/java/com/iab/gdpr/RangeEntry.java
+++ b/src/main/java/com/iab/gdpr/RangeEntry.java
@@ -43,4 +43,27 @@ public class RangeEntry {
 	public int getMinVendorId() {
 		return minVendorId;
 	}
+
+	public static boolean isVendorIdInRange(int vendorId, List<RangeEntry> rangeEntries) {
+		int limit = rangeEntries.size();
+		if (limit == 0) {
+			return false;
+		}
+		int index = limit / 2;
+		while (index >= 0 && index < limit) {
+			RangeEntry entry = rangeEntries.get(index);
+			if (entry.containsVendorId(vendorId)) {
+				return true;
+			}
+			if (index == 0 || index == limit - 1) {
+				return false;
+			}
+			if (entry.idIsGreaterThanMax(vendorId)) {
+				index = (index + ((limit - index) / 2));
+			} else {
+				index = index / 2;
+			}
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
## What does this do?
- Adds `PubRestrictionEntry` list accessor to `ConsentInfo` interface (`getPublisherRestrictions`)
- Adds override implementation of `getPublisherRestrictions` to `ConsentStringParserV2`
- Adds appropriate accessors onto the PubRestrictionEntry class
- Refactors some of the "finding vendor in range entry list" functionality because it's used so often